### PR TITLE
Update python_version for 3.13

### DIFF
--- a/bigquery.json
+++ b/bigquery.json
@@ -18,7 +18,7 @@
     "latest_tested_versions": [
         "Cloud, tested on July 8, 2021"
     ],
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "app_wizard_version": "1.0.0",
     "configuration": {

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)